### PR TITLE
Do retain original DANDI Copyright + list range of years for JHU/APL

### DIFF
--- a/web/src/components/DandiFooter.vue
+++ b/web/src/components/DandiFooter.vue
@@ -15,7 +15,8 @@
       </cookie-law>
       <v-row>
         <v-col offset="2">
-          &copy; 2024 JHU/APL.<br>
+          &copy; 2019 - 2024 The DANDI Team<br>
+          &copy; 2024 - 2025 JHU/APL.<br>
           <!-- version
           <a
             class="version-link"


### PR DESCRIPTION
I do not think it is entirely kosher to remove copyright statements ;-)

2024 for JHU/APL for tomorrow's "opening" would look stale.

For the year fix for DANDI -- will get "fixed" soon so merge should work out I hope

- https://github.com/dandi/dandi-archive/pull/2183