### PR TITLE
Update GitHub actions to run on prod

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,7 +5,7 @@ on:
       - "web/**"
   push:
     branches:
-      - master
+      - prod
     paths-ignore:
       - "web/**"
   schedule:

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -3,7 +3,7 @@ name: Test Integration with dandi-cli
 on:
   push:
     branches:
-      - master
+      - prod
     paths-ignore:
       - "web/**"
   pull_request:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - prod
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - prod
 
 jobs:
   release:


### PR DESCRIPTION
Closes #34 

We use `prod` as a deloyment branch, not `master`