### PR TITLE
Add note about .edu email. Add question for funding identifier

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ This is the simplest configuration for developers to start with.
 ### Run Application
 1. Run the following commands in three separate VSCode built-in-terminals:
    1. `./manage.py runserver_plus 0.0.0.0:8000`
-   1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
+   1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues celery,calculate_sha256,ingest_zarr_archive,manifest-worker --beat`
    1. `cd web/ && npm install && npm run dev`
 1. Access the site, starting at http://localhost:8000/admin/
 1. When finished, use `Ctrl+C`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,7 +82,7 @@ but allows developers to run Python code on their native system.
 1. Run the Celery app
     1. Start a new terminal
     1. Run `export UV_ENV_FILE=./dev/.env.docker-compose-native`
-    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
+    1. `uv run celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip -Q celery,calculate_sha256,ingest_zarr_archive,manifest-worker -B`
 1. When finished, run `docker compose stop`
 
 ## Testing

--- a/Procfile
+++ b/Procfile
@@ -6,6 +6,6 @@ web: gunicorn --config gunicorn.conf.py dandiapi.wsgi
 # This is OK for now because of how lightweight all high priority tasks currently are,
 # but we may need to switch back to a dedicated worker in the future.
 # The queue `celery` is the default queue.
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B --without-gossip --without-mingle
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues celery --beat
 # The checksum-worker calculates blob checksums and updates zarr checksum files
-checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256,ingest_zarr_archive --without-gossip --without-mingle
+checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --without-mingle --without-heartbeat --without-gossip --queues calculate_sha256,ingest_zarr_archive

--- a/dandiapi/api/templates/api/account/base.html
+++ b/dandiapi/api/templates/api/account/base.html
@@ -20,8 +20,8 @@
       transform: translate(-50%, -50%);
     }
     .input-field {
-      margin-top: 10%;
-      margin-bottom: 10%;
+      margin-top: 8%;
+      margin-bottom: 8%;
     }
     .logo-container {
       padding-left: 2%;
@@ -31,6 +31,15 @@
       height: 40px;
       margin-top: 10px;
     }
+    .logo-title {
+      font-size: 1.3rem;
+    }
+    a {
+      color: rgb(183, 28, 28) !important;
+    }
+    .btn {
+      background-color: rgb(245, 124, 0);
+    }
   </style>
 </head>
 
@@ -38,8 +47,8 @@
   <nav style="background-color: #f5f5f5;">
     <div class="nav-wrapper logo-container">
       <a href="{{ dandi_web_app_url }}" class="brand-logo">
-        EMBER-DANDI
         <img src="https://raw.githubusercontent.com/aplbrain/dandi-archive/prod/web/src/assets/ember-logo.png" class="logo">
+        <span class="logo-title"><b>EMBER-DANDI</b></span>
       </a>
     </div>
   </nav>

--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -3,6 +3,12 @@
 {% block body %}
   <h5>Welcome to EMBER-DANDI! Please take a moment to fill out this form.</h5>
   <h6><b>Note:</b> No account is necessary to access public data!</h6>
+
+  <div>
+    <b>
+        Please note that setting your primary email address in GitHub to a academic email (.EDU) will enable faster approval.
+    </b>
+  </div>
   <form method="POST" class="col s12">
     {% csrf_token %}
     {{ form }}

--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -10,7 +10,7 @@
     <div class="row">
       <div class="col s12">
         <b>
-            Please note that setting your primary email address in GitHub to an academic email (.edu) will enable faster approval.
+            Please note that setting your primary email address in GitHub to an academic email (.edu) may enable faster approval.
         </b>
       </div>
       <div class="col m6 offset-m3 s12">

--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -4,15 +4,15 @@
   <h5>Welcome to EMBER-DANDI! Please take a moment to fill out this form.</h5>
   <h6><b>Note:</b> No account is necessary to access public data!</h6>
 
-  <div>
-    <b>
-        Please note that setting your primary email address in GitHub to a academic email (.EDU) will enable faster approval.
-    </b>
-  </div>
   <form method="POST" class="col s12">
     {% csrf_token %}
     {{ form }}
     <div class="row">
+      <div class="col s12">
+        <b>
+            Please note that setting your primary email address in GitHub to an academic email (.edu) will enable faster approval.
+        </b>
+      </div>
       <div class="col m6 offset-m3 s12">
         {% for question in questions %}
           <div class="input-field">
@@ -30,7 +30,7 @@
           </b></i>
         </div>
 
-        <button id="btn" class="btn waves-effect waves-light blue" type="submit" disabled>
+        <button id="btn" class="btn waves-effect waves-light" type="submit" disabled>
           <span>Submit</span>
           <i class="material-icons right">send</i>
         </button>

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -139,9 +139,9 @@ def user_questionnaire_form_view(request: AuthenticatedRequest) -> HttpResponse:
                     '@alleninstitute.org',
                     '@nih.gov',
                     '@janelia.hhmi.org',
-                    '@ccf.org',
-                    '.ac.uk',
-                    '.mcgill.ca',
+                    '@ccf.org',  # Cleveland Clinic
+                    # '.ac.uk',
+                    # '.mcgill.ca',
                 ]
             )
 

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -48,10 +48,14 @@ def auth_token_view(request: AuthenticatedRequest) -> HttpResponseBase:
 QUESTIONS = [
     {'question': 'First Name', 'max_length': 100},
     {'question': 'Last Name', 'max_length': 100},
-    {'question': 'Affiliation(s)', 'max_length': 1000},
+    {'question': 'Academic Affiliation(s)', 'max_length': 1000},
     {'question': 'Lab/project website', 'max_length': 1000},
     {
-        'question': 'Please describe how your research project will utilize DANDI resources.',
+        'question': 'Please describe how your research project will utilize EMBER-DANDI resources.',
+        'max_length': 1000,
+    },
+    {
+        'question': 'If your research is funded by NIH, NSF, or another U.S. institution, please provide the relevant funding identifier(s).',  # noqa: E501
         'max_length': 1000,
     },
 ]

--- a/dandiapi/settings/base.py
+++ b/dandiapi/settings/base.py
@@ -187,6 +187,8 @@ SWAGGER_SETTINGS = {
 CELERY_BROKER_HEARTBEAT = 20
 # Allow this to be configurable, but keep the default as the number of CPU cores
 CELERY_WORKER_CONCURRENCY: int | None = env.int('DJANGO_CELERY_WORKER_CONCURRENCY', default=None)
+# Work around https://github.com/celery/kombu/issues/2237
+CELERY_WORKER_ENABLE_REMOTE_CONTROL = False
 
 _dandi_log_level: str = env.str('DJANGO_DANDI_LOG_LEVEL', default='INFO')
 # Configure the logging level on all DANDI loggers.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -44,9 +44,11 @@ services:
       "--app", "dandiapi.celery",
       "worker",
       "--loglevel", "INFO",
+      "--without-mingle",
       "--without-heartbeat",
-      "-Q", "celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
-      "-B"
+      "--without-gossip",
+      "--queues", "celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
+      "--beat"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false


### PR DESCRIPTION
# Changes
- Added a note about using a .edu email address for your primary GitHub email for faster approval
   - note: I am not sure how much this will actually help, as this form appears _after_ the user has already authenticated with GitHub
- Updated "Affiliation(s)" question to be "Academic Affiliation(s)" (to satisfy our follow-up question 1)
- Added a question asking for funding identifier (to satisfy our follow-up question 2)

<img width="1494" height="924" alt="Screenshot 2026-05-28 at 4 58 05 PM" src="https://github.com/user-attachments/assets/f6f11ae4-c059-4538-8ad2-3f54c7015ee1" />

# Testing
- checkout the branch, run both the frontend and backend of dandi-archive
- you may need to change line 91 in auth.py (LOCALLY ONLY) to see the form while running locally, as the local login process does not use GitHub and thus appears a little different
```
-            f'?{request.META["QUERY_STRING"]}&QUESTIONS={json.dumps(COLLECT_USER_NAME_QUESTIONS)}'
+            f'?{request.META["QUERY_STRING"]}&QUESTIONS={json.dumps(NEW_USER_QUESTIONS)}'
```

# Notes
- I also had to cherry-pick 2 commits from dandi-archive master in order to get the backend to run locally, these are: https://github.com/dandi/dandi-archive/commit/6a007789bcc389d4951a65a3a8af33f08a15bf31 & https://github.com/dandi/dandi-archive/commit/c10a585c90a6b6ed66801ee19be47a94006083e0
  - these commits have NOT been released yet as of May 28 (https://github.com/dandi/dandi-archive/releases), which is why they were cherry-picked rather than updated in our syncing